### PR TITLE
Fix hydration issues with ad components and remove unoptimized prop from AvatarImage

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,8 +37,6 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head />
-      <AdSenseScript />
-      <GrowMeScript />
       <body className={`${inter.variable} ${playfair.variable} font-sans`}>
         <ThemeProvider>
           <CustomCursor />
@@ -48,6 +46,9 @@ export default function RootLayout({
             <Footer />
           </div>
         </ThemeProvider>
+        {/* Ad scripts moved inside body to prevent hydration issues */}
+        <AdSenseScript />
+        <GrowMeScript />
       </body>
     </html>
   );

--- a/src/components/ads/AdManager.tsx
+++ b/src/components/ads/AdManager.tsx
@@ -8,6 +8,7 @@ import VerticalAd from './VerticalAd';
 import SidebarAd from './SidebarAd';
 import InArticleAd from './InArticleAd';
 import AutoRelaxedAd from './AutoRelaxedAd';
+import ClientOnlyAd from './ClientOnlyAd';
 
 type AdType = 'article' | 'horizontal' | 'vertical' | 'sidebar' | 'in-article' | 'autorelaxed';
 
@@ -50,7 +51,9 @@ const AdManager = ({ type, className = '', children }: AdManagerProps) => {
   return (
     <AdErrorBoundary>
       <div className={containerClass}>
-        {renderAd()}
+        <ClientOnlyAd>
+          {renderAd()}
+        </ClientOnlyAd>
         {children}
       </div>
     </AdErrorBoundary>

--- a/src/components/ads/AdSense.tsx
+++ b/src/components/ads/AdSense.tsx
@@ -60,14 +60,16 @@ const AdSense: React.FC<AdSenseProps> = ({
   return (
     <AdErrorBoundary>
       <div ref={adRef} className={`ad-container ${className}`}>
-        <ins
-          className="adsbygoogle"
-          style={style}
-          data-ad-client={ADSENSE_PUBLISHER_ID}
-          data-ad-slot={adSlot}
-          data-ad-format={adFormat}
-          data-full-width-responsive={fullWidthResponsive ? 'true' : 'false'}
-        />
+        {typeof window !== 'undefined' && (
+          <ins
+            className="adsbygoogle"
+            style={style}
+            data-ad-client={ADSENSE_PUBLISHER_ID}
+            data-ad-slot={adSlot}
+            data-ad-format={adFormat}
+            data-full-width-responsive={fullWidthResponsive ? 'true' : 'false'}
+          />
+        )}
       </div>
     </AdErrorBoundary>
   );

--- a/src/components/ads/AdSenseAdUnit.tsx
+++ b/src/components/ads/AdSenseAdUnit.tsx
@@ -99,7 +99,7 @@ const AdSenseAdUnit: React.FC<AdSenseAdUnitProps> = ({
         className={`ad-container ${className}`}
         data-ad-status={isAdLoaded ? 'loaded' : isVisible ? 'loading' : 'pending'}
       >
-        {isVisible && (
+        {isVisible && typeof window !== 'undefined' && (
           <ins
             className="adsbygoogle"
             style={style}

--- a/src/components/ads/ClientOnlyAd.tsx
+++ b/src/components/ads/ClientOnlyAd.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { ReactNode } from 'react';
+
+// Create a client-only wrapper component
+const ClientOnlyAd = ({ children }: { children: ReactNode }) => {
+  return <>{children}</>;
+};
+
+// Export a dynamic version that only renders on the client
+export default dynamic(() => Promise.resolve(ClientOnlyAd), {
+  ssr: false,
+});

--- a/src/components/ads/index.ts
+++ b/src/components/ads/index.ts
@@ -11,3 +11,4 @@ export { default as AutoRelaxedAd } from './AutoRelaxedAd';
 export { default as AdManager } from './AdManager';
 export { default as AdSenseVerification } from './AdSenseVerification';
 export { default as GrowMeScript } from './GrowMeScript';
+export { default as ClientOnlyAd } from './ClientOnlyAd';

--- a/src/components/articles/ArticleCard.tsx
+++ b/src/components/articles/ArticleCard.tsx
@@ -136,7 +136,7 @@ const ArticleCard = ({ article, variant = 'default', className }: ArticleCardPro
         <CardFooter className="pt-0 flex items-center justify-between">
           <div className="flex items-center space-x-2">
             <Avatar className="h-8 w-8">
-              <AvatarImage src={article.author.image} alt={article.author.name} unoptimized />
+              <AvatarImage src={article.author.image} alt={article.author.name} />
               <AvatarFallback>{getInitials(article.author.name)}</AvatarFallback>
             </Avatar>
             <div>


### PR DESCRIPTION
This PR fixes the build error and hydration issues by:

1. Removing the `unoptimized` prop from the `AvatarImage` component in ArticleCard.tsx
2. Creating a new ClientOnlyAd component that uses Next.js's dynamic import with ssr: false
3. Updating AdManager, AdSense, and AdSenseAdUnit components to prevent server-side rendering of ad elements
4. Moving ad scripts inside the body tag in layout.tsx

These changes prevent hydration mismatches by ensuring that ad components only render on the client side.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author